### PR TITLE
Normalize preset patterns to 16 steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,8 +151,11 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
-# mkdocs documentation
-/site
+# mkdocs documentation output is normally stored in a top-level
+# "site" directory. The application code now uses a directory with the
+# same name, so we remove this ignore rule to ensure the application's
+# source files are tracked.
+#/site
 
 # mypy
 .mypy_cache/

--- a/site/app.js
+++ b/site/app.js
@@ -1,0 +1,19 @@
+function applyPresetData(p) {
+  const defaultStep = { note: 0, vel: 0, rat: 1, on: false };
+  ['leadPattern', 'bassPattern', 'hatsPattern'].forEach(key => {
+    let arr = Array.isArray(p[key]) ? p[key] : [];
+    arr = arr.slice(0, 16).map(step => ({
+      note: step && step.note !== undefined ? step.note : defaultStep.note,
+      vel: step && step.vel !== undefined ? step.vel : defaultStep.vel,
+      rat: step && step.rat !== undefined ? step.rat : defaultStep.rat,
+      on: step && step.on !== undefined ? step.on : defaultStep.on
+    }));
+    while (arr.length < 16) {
+      arr.push({ ...defaultStep });
+    }
+    p[key] = arr;
+  });
+  return p;
+}
+
+module.exports = { applyPresetData };


### PR DESCRIPTION
## Summary
- handle leadPattern, bassPattern and hatsPattern data to always have 16 steps
- default missing step fields to safe values
- comment out mkdocs site ignore so app sources are tracked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c616b4cbc48325a099baa68e291915