### PR TITLE
Handle non-finite audio levels in meter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,7 +152,8 @@ venv.bak/
 .ropeproject
 
 # mkdocs documentation
-/site
+/site/*
+!site/app.js
 
 # mypy
 .mypy_cache/

--- a/site/app.js
+++ b/site/app.js
@@ -1,0 +1,19 @@
+// Simple meter drawing utility.
+// Assumes `lvl` and drawing context `ctx` are defined globally.
+// `lvl` is expected in decibels where 0 is max and negative values
+// represent quieter levels down to -60 dB.
+function drawMeter() {
+  if (!isFinite(lvl)) {
+    lvl = -60;
+  }
+  const clamped = Math.max(lvl, -60);
+  const norm = (clamped + 60) / 60;
+  const width = ctx.canvas.width * norm;
+  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  ctx.fillStyle = 'green';
+  ctx.fillRect(0, 0, width, ctx.canvas.height);
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { drawMeter };
+}


### PR DESCRIPTION
## Summary
- safeguard meter rendering by clamping non-finite audio levels to -60 dB
- allow committing site assets by exempting site/app.js from ignore list

## Testing
- `node -e "require('./site/app.js')"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c616b33a9c832590fa646831086c10