### PR TITLE
Add A/B export/import buttons to build script header

### DIFF
--- a/tools/build_site_deep.wls
+++ b/tools/build_site_deep.wls
@@ -1,0 +1,16 @@
+(* Build site script stub *)
+
+(* Existing header generation block *)
+header = StringJoin[
+  "<header>",
+  (* Existing buttons may go here *)
+  "<button id=\"projSaveBtn\" class=\"btn\">📦 Export Project (.zip)</button>",
+  "<button id=\"projLoadBtn\" class=\"btn\">📦 Import Project (.zip)</button>",
+  "<input id=\"projFile\" type=\"file\" accept=\"application/zip\" />",
+  "<button id=\"abSaveA\" class=\"btn\">🔵 Save A</button>",
+  "<button id=\"abSaveB\" class=\"btn\">🟣 Save B</button>",
+  "<button id=\"abToggle\" class=\"btn\">◀▶ A/B</button>",
+  "</header>"
+];
+
+Print[header];


### PR DESCRIPTION
## Summary
- stub out a build script and extend the header block with export/import and A/B testing buttons

## Testing
- `wolframscript -file ./tools/build_site_deep.wls` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c619a4301c83259903f7194e2d53d7