### PR TITLE
Add limiter controls to FX & Dynamics build script

### DIFF
--- a/tools/build_site_deep.wls
+++ b/tools/build_site_deep.wls
@@ -1,7 +1,19 @@
 #!/usr/bin/env wolframscript
 
 (* Build site index with safe JSON injection *)
-presets = <||>;
+
+(* FX & Dynamics controls *)
+presets = <|
+  "fxDynamics" -> {
+    (* Compressor/sidechain controls would appear here *)
+    <|"id"->"lim_thresh","type"->"range","label"->"Limiter Threshold (dB)",
+      "min"->-12,"max"->0,"step"->0.5,"value"->-1,"cmd"->"lim_thresh"|>,
+    <|"id"->"lim_drums_on","type"->"select","label"->"Limiter Drums","cmd"->"lim_drums_on"|>,
+    <|"id"->"lim_bass_on","type"->"select","label"->"Limiter Bass","cmd"->"lim_bass_on"|>,
+    <|"id"->"lim_lead_on","type"->"select","label"->"Limiter Lead","cmd"->"lim_lead_on"|>,
+    <|"id"->"lim_fx_on","type"->"select","label"->"Limiter FX","cmd"->"lim_fx_on"|>
+  }
+|>;
 
 presetJSON = ExportString[presets, "JSON"];
 presetBase64 = ExportString[presetJSON, "Base64"];


### PR DESCRIPTION
## Summary
- define FX & Dynamics limiter controls in `build_site_deep.wls`

## Testing
- `wolframscript -file ./tools/build_site_deep.wls` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c61ac50b9c8325875b96c2cdf13dc7