### PR TITLE
Document site rebuild step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# bodzin_gen
+
+After modifying `tools/build_site_deep.wls`, regenerate the site by running:
+
+```
+wolframscript -file ./tools/build_site_deep.wls
+```
+
+The generated files under `site/` should be committed to version control.


### PR DESCRIPTION
## Summary
- Add README with instructions to run `wolframscript -file ./tools/build_site_deep.wls` when `tools/build_site_deep.wls` changes
- Note that generated files under `site/` should be tracked in version control

## Testing
- `wolframscript -file ./tools/build_site_deep.wls` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c638494a98832598aeb07c53da3683