### PR TITLE
Remove newlines from preset base64 export

### DIFF
--- a/tools/build_site_deep.wls
+++ b/tools/build_site_deep.wls
@@ -16,7 +16,7 @@ presets = <|
 |>;
 
 presetJSON = ExportString[presets, "JSON"];
-presetBase64 = ExportString[presetJSON, "Base64"];
+presetBase64 = StringReplace[ExportString[presetJSON, "Base64"], {"\n" -> "", "\r" -> ""}];
 presetJS = "JSON.parse(atob('" <> presetBase64 <> "'))";
 
 html = StringRiffle[{


### PR DESCRIPTION
## Summary
- strip newline and carriage return characters from the base64 export used in the preset script embedding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caa76d5b5c83259363d1718e22bd0f