### PR TITLE
Add TODO section with Wolfram procedural music note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # bodzin_gen
 
 Static site assets live in `site/`. They are maintained manually and should remain committed to version control. No Wolfram tooling is required.
+
+## TODO / Future Work
+
+- Investigate opportunities to incorporate Wolfram tooling to support procedural music generation workflows while ensuring it does not reintroduce low-level markup generation.


### PR DESCRIPTION
## Summary
- introduce a TODO / Future Work section in the README
- note the potential future use of Wolfram for procedural music workflows without reviving low-level markup generation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cab2ca04c08325a1120ec94ed3e711